### PR TITLE
solves i227 deployment with Dao Value Guarded Values

### DIFF
--- a/contracts/StakingHbbft.sol
+++ b/contracts/StakingHbbft.sol
@@ -357,7 +357,7 @@ contract StakingHbbft is Initializable, OwnableUpgradeable, ReentrancyGuardUpgra
         delegatorMinStakeAllowedParams[3] = 200 ether;
         delegatorMinStakeAllowedParams[4] = 250 ether;
 
-        setAllowedChangeableParameter(
+        initAllowedChangeableParameter(
             "setDelegatorMinStake(uint256)",
             "delegatorMinStake()",
             delegatorMinStakeAllowedParams

--- a/contracts/TxPermissionHbbft.sol
+++ b/contracts/TxPermissionHbbft.sol
@@ -165,7 +165,7 @@ contract TxPermissionHbbft is Initializable, OwnableUpgradeable, ITxPermission, 
         minGasPriceAllowedParams[9] = 8 gwei;
         minGasPriceAllowedParams[10] = 10 gwei;
 
-        setAllowedChangeableParameter("setMinimumGasPrice(uint256)", "minimumGasPrice()", minGasPriceAllowedParams);
+        initAllowedChangeableParameter("setMinimumGasPrice(uint256)", "minimumGasPrice()", minGasPriceAllowedParams);
 
         uint256[] memory blockGasLimitAllowedParams = new uint256[](10);
         blockGasLimitAllowedParams[0] = 100_000_000;
@@ -179,7 +179,7 @@ contract TxPermissionHbbft is Initializable, OwnableUpgradeable, ITxPermission, 
         blockGasLimitAllowedParams[8] = 900_000_000;
         blockGasLimitAllowedParams[9] = 1000_000_000;
 
-        setAllowedChangeableParameter("setBlockGasLimit(uint256)", "blockGasLimit()", blockGasLimitAllowedParams);
+        initAllowedChangeableParameter("setBlockGasLimit(uint256)", "blockGasLimit()", blockGasLimitAllowedParams);
     }
 
     /// @dev Adds the address for which transactions of any type must be allowed.

--- a/contracts/ValueGuards.sol
+++ b/contracts/ValueGuards.sol
@@ -99,7 +99,7 @@ contract ValueGuards is OwnableUpgradeable {
         string memory setter,
         string memory getter,
         uint256[] memory params
-    ) public virtual onlyOwner {
+    ) public onlyOwner {
         allowedParameterRange[bytes4(keccak256(bytes(setter)))] = ParameterRange(
             bytes4(keccak256(bytes(getter))),
             params
@@ -111,9 +111,30 @@ contract ValueGuards is OwnableUpgradeable {
      * @dev Removes the allowed changeable parameter for a given function selector.
      * @param funcSelector The function selector for which the allowed changeable parameter should be removed.
      */
-    function removeAllowedChangeableParameter(string memory funcSelector) public virtual onlyOwner {
+    function removeAllowedChangeableParameter(string memory funcSelector) public onlyOwner{
         delete allowedParameterRange[bytes4(keccak256(bytes(funcSelector)))];
         emit RemoveChangeAbleParameter(funcSelector);
+    }
+
+    // =============================================== Initializers ====================================================
+
+    
+    /**
+     * @dev Inits the allowed changeable parameter for a specific setter function.
+     * @param setter The name of the setter function.
+     * @param getter The name of the getter function.
+     * @param params The array of allowed parameter values.
+     */
+    function initAllowedChangeableParameter(
+        string memory setter,
+        string memory getter,
+        uint256[] memory params
+    ) public onlyInitializing {
+        allowedParameterRange[bytes4(keccak256(bytes(setter)))] = ParameterRange(
+            bytes4(keccak256(bytes(getter))),
+            params
+        );
+        emit SetChangeAbleParameter(setter, getter, params);
     }
 
     // =============================================== Internal ========================================================


### PR DESCRIPTION
Using initializer strategy to solve the problem that only the DAO could be the entity that is allowed to specify value guards.

https://github.com/DMDcoin/diamond-contracts-core/issues/227