### PR TITLE
task to get transaction calldata to upgrade core contracts using DAO

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -13,6 +13,7 @@ import 'solidity-docgen';
 import 'hardhat-tracer';
 
 import './tasks/make_spec';
+import './tasks/getContractUpgradeCalldata';
 
 
 const getMnemonic = () => {

--- a/tasks/getContractUpgradeCalldata.ts
+++ b/tasks/getContractUpgradeCalldata.ts
@@ -1,0 +1,57 @@
+import { task, types } from 'hardhat/config';
+import { attachProxyAdminV5 } from '@openzeppelin/hardhat-upgrades/dist/utils';
+
+let KnownContracts = new Map<string, string>([
+    ["ValidatorSetHbbft", "0x1000000000000000000000000000000000000001"],
+    ["BlockRewardHbbft", "0x2000000000000000000000000000000000000001"],
+    ["RandomHbbft", "0x3000000000000000000000000000000000000001"],
+    ["TxPermissionHbbft", "0x4000000000000000000000000000000000000001"],
+    ["CertifierHbbft", "0x5000000000000000000000000000000000000001"],
+    ["KeyGenHistory", "0x7000000000000000000000000000000000000001"],
+    ["StakingHbbft", "0x1100000000000000000000000000000000000001"],
+    ["ConnectivityTrackerHbbft", "0x1200000000000000000000000000000000000001"],
+    ["BonusScoreSystem", "0x1300000000000000000000000000000000000001"],
+]);
+
+
+task("getUpgradeCalldata", "Get contract upgrade calldata to use in DAO proposal")
+    .addParam("contract", "The core contract address to upgrade")
+    .addOptionalParam("impl", "Address of new core contract implementation", undefined, types.string)
+    .setAction(async (taskArgs, hre) => {
+        const { contract, impl } = taskArgs;
+
+        if (!KnownContracts.has(contract)) {
+            throw new Error(`${contract} is unknown`);
+        }
+
+        const proxyAddress = KnownContracts.get(contract)!;
+
+        let implementationAddress: string = impl;
+        if (impl == undefined) {
+            const [deployer] = await hre.ethers.getSigners();
+            const contractFactory = await hre.ethers.getContractFactory(contract, deployer);
+
+            const result = await hre.upgrades.deployImplementation(
+                contractFactory,
+                {
+                    getTxResponse: false,
+                    redeployImplementation: 'always',
+                }
+            );
+            implementationAddress = result as string;
+        }
+
+        const proxyAdminAddress = await hre.upgrades.erc1967.getAdminAddress(proxyAddress);
+
+        const proxyAdmin = await attachProxyAdminV5(hre, proxyAdminAddress);
+
+        const calldata = proxyAdmin.interface.encodeFunctionData("upgradeAndCall", [
+            proxyAddress,
+            implementationAddress,
+            hre.ethers.hexlify(new Uint8Array()),
+        ]);
+
+        console.log("contract:", contract);
+        console.log("calldata:", calldata);
+        console.log("  target:", proxyAdminAddress);
+    });

--- a/tasks/index.ts
+++ b/tasks/index.ts
@@ -1,1 +1,2 @@
 import './make_spec.ts'
+import './getContractUpgradeCalldata.ts'


### PR DESCRIPTION
Task usage:

```shell
npx hardhat --network <network name> getUpgradeCalldata --contract <contract name>
```
This command will deploy new version of StakingHbbft implementation contract and print upgrade calldata with target address, e.g:
```shell
contract: StakingHbbft
calldata: 0x9623609d000000000000000000000000363f748e75bb1e80fb28f57a39c81623cbf83dc1000000000000000000000000c9ee155fae0f8b74b99ace0e7dbc0f5af8d0d28400000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000
  target: 0xbed56463Acd6cF4945683bBEa9BA79Ce3322d16D
```

To use already deployed implementation contract it's address should be passed in `--impl` argument:
```shell
npx hardhat --network <network name> getUpgradeCalldata --contract <contract name> --impl 0xC0D9Dc431CA7a3B2087EED9906E92bfbe89485CC
```