### PR TITLE
calldata with arguments

### DIFF
--- a/contracts/ValidatorSetHbbft.sol
+++ b/contracts/ValidatorSetHbbft.sol
@@ -222,6 +222,10 @@ contract ValidatorSetHbbft is Initializable, OwnableUpgradeable, IValidatorSetHb
     }
 
     function initializeV2(address _connectivityTracker) external reinitializer(2) {
+        if (_connectivityTracker == address(0)) {
+            revert ZeroAddress();
+        }
+
         connectivityTracker = _connectivityTracker;
     }
 

--- a/contracts/ValidatorSetHbbft.sol
+++ b/contracts/ValidatorSetHbbft.sol
@@ -221,6 +221,10 @@ contract ValidatorSetHbbft is Initializable, OwnableUpgradeable, IValidatorSetHb
         maxValidators = 25;
     }
 
+    function initializeV2(address _connectivityTracker) external reinitializer(2) {
+        connectivityTracker = _connectivityTracker;
+    }
+
     /// @dev Called by the system when a pending validator set is ready to be activated.
     /// Only valid when msg.sender == SUPER_USER (EIP96, 2**160 - 2).
     /// After this function is called, the `getValidators` getter returns the new validator set.


### PR DESCRIPTION
Usage with arguments:

```shell
npx hardhat --network <network name> getUpgradeCalldata \
    --contract <contract name> \
    --impl 0xC0D9Dc431CA7a3B2087EED9906E92bfbe89485CC \
    --init-func initializeV2 "arg1" "arg2" "arg3"
```