### PR TITLE
BlockReward contract improvements and unit tests coverage

### DIFF
--- a/contracts/mockContracts/BlockRewardHbbftMock.sol
+++ b/contracts/mockContracts/BlockRewardHbbftMock.sol
@@ -14,6 +14,10 @@ contract BlockRewardHbbftMock is BlockRewardHbbft {
         governancePotAddress = payable(_address);
     }
 
+    function resetEarlyEpochEnd() external {
+        earlyEpochEnd = false;
+    }
+
     function getPotsShares(uint256 numValidators) external view returns (PotsShares memory) {
         return _getPotsShares(numValidators);
     }

--- a/scripts/getNetworkState.ts
+++ b/scripts/getNetworkState.ts
@@ -1,0 +1,75 @@
+import { BlockRewardHbbft, ConnectivityTrackerHbbft, ValidatorSetHbbft } from "../src/types";
+import { ethers } from "hardhat";
+
+async function getNetworkState() {
+  const ValidatorSetHbbft = await ethers.getContractFactory("ValidatorSetHbbft");
+  const validatorSet = ValidatorSetHbbft.attach("0x1000000000000000000000000000000000000001") as ValidatorSetHbbft;
+
+  const ConnectivityTracker = await ethers.getContractFactory("ConnectivityTrackerHbbft");
+  const connectivityTracker = ConnectivityTracker.attach(
+    "0x1200000000000000000000000000000000000001"
+  ) as ConnectivityTrackerHbbft;
+
+  const BlockRewardHbbft = await ethers.getContractFactory("BlockRewardHbbft");
+  const blockReward = BlockRewardHbbft.attach("0x2000000000000000000000000000000000000001") as BlockRewardHbbft;
+
+  const epoch = await connectivityTracker.currentEpoch({ blockTag: 450000n });
+  console.log("[epoch] current epoch: ", await connectivityTracker.currentEpoch());
+  console.log("[epoch] epoch faulty validators: ", await connectivityTracker.countFaultyValidators(epoch));
+  console.log("[epoch] epoch - 1 faulty validators: ", await connectivityTracker.countFaultyValidators(epoch - 1n));
+  console.log("[epoch] epoch - 2 faulty validators: ", await connectivityTracker.countFaultyValidators(epoch - 2n));
+
+  console.log("[validators] current: ", await validatorSet.getValidators());
+  console.log("[validators] pending: ", await validatorSet.getPendingValidators());
+  console.log("[validators] previous: ", await validatorSet.getPreviousValidators());
+
+  const prevValidators = await validatorSet.getPreviousValidators();
+
+  for (const validator of prevValidators) {
+    console.log("\nvalidator: ", validator);
+    console.log("score epoch N: ", await connectivityTracker.getValidatorConnectivityScore(epoch, validator));
+    console.log("score epoch N-1: ", await connectivityTracker.getValidatorConnectivityScore(epoch - 1n, validator));
+  }
+
+  console.log("[block reward] fixed reward rate: ", await blockReward.VALIDATOR_FIXED_REWARD_PERCENT());
+  console.log("[block reward] conn tracker: ", await blockReward.connectivityTracker());
+  console.log("[conn tracker] bonus score system: ", await connectivityTracker.bonusScoreContract());
+
+  console.log("[validator set] connectivityTracker: ", await validatorSet.connectivityTracker());
+  console.log("[validator set] get staking: ", await validatorSet.getStakingContract());
+
+  console.log("[conn tracker] flagged count: ", await connectivityTracker.getFlaggedValidatorsByEpoch(epoch));
+  console.log(
+    "[conn tracker] flagged count epoch-1: ",
+    await connectivityTracker.getFlaggedValidatorsByEpoch(epoch - 1n)
+  );
+
+  console.log("[block reward] min validator reward: ", await blockReward.validatorMinRewardPercent(epoch));
+
+  for (let block = 449000n; block <= 450019n; block = block + 1n) {
+    console.log(`block: ${block} -> early epoch end ${await blockReward.earlyEpochEnd({ blockTag: block })}`);
+    console.log(`block: ${block} -> current validators ${await validatorSet.getValidators({ blockTag: block })}`);
+  }
+
+  console.log("pending: ", await validatorSet.getPendingValidators({ blockTag: 450009n }));
+
+  for (const validator of prevValidators) {
+    console.log(
+      `${validator}            available since: ${await validatorSet.validatorAvailableSince(validator, {
+        blockTag: 450019n,
+      })}`
+    );
+    console.log(
+      `${validator} available since last write: ${await validatorSet.validatorAvailableSinceLastWrite(validator, {
+        blockTag: 450019n,
+      })}`
+    );
+  }
+}
+
+getNetworkState()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/triggerReward.ts
+++ b/scripts/triggerReward.ts
@@ -1,0 +1,132 @@
+import { BlockRewardHbbft } from "../src/types";
+import { ethers } from "hardhat";
+import * as helpers from "@nomicfoundation/hardhat-network-helpers";
+
+const SystemAccountAddress = "0xffffFFFfFFffffffffffffffFfFFFfffFFFfFFfE";
+
+interface JsonRpcRequest {
+  jsonrpc: string;
+  method: string;
+  params?: any[];
+  id: number | string;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: string;
+  result?: any;
+  error?: {
+    code: number;
+    message: string;
+    data?: any;
+  };
+  id: number | string;
+}
+
+class EthereumCallError extends Error {
+  code: number;
+  message: string;
+  data: any;
+
+  constructor({ _code, _message, _data }: { _code: number; _message: string; _data: string }) {
+    super();
+    this.code = _code;
+    this.message = _message;
+    this.data = _data;
+  }
+}
+
+async function triggerReward() {
+  const [signer] = await ethers.getSigners();
+
+  const BlockRewardHbbft = await ethers.getContractFactory("BlockRewardHbbft");
+  const blockReward = BlockRewardHbbft.attach("0x2000000000000000000000000000000000000001") as BlockRewardHbbft;
+
+  console.log("[net] latest block: ", await ethers.provider.getBlockNumber());
+
+  await helpers.impersonateAccount(SystemAccountAddress);
+
+  const systemSigner = await ethers.getSigner(SystemAccountAddress);
+
+  const result = await blockReward.connect(systemSigner).reward(true, { gasLimit: 5_000_000 });
+  const receipt = await result.wait();
+
+  console.log("receipt: ", receipt);
+
+  await helpers.stopImpersonatingAccount(SystemAccountAddress);
+}
+
+async function getTxRevertReason() {
+  const BlockRewardHbbft = await ethers.getContractFactory("BlockRewardHbbft");
+  const blockReward = BlockRewardHbbft.attach("0x2000000000000000000000000000000000000001") as BlockRewardHbbft;
+
+  const calldata = blockReward.interface.encodeFunctionData("reward", [true]);
+
+  try {
+    const replayTx = {
+      from: SystemAccountAddress,
+      to: "0x2000000000000000000000000000000000000001",
+      gas: "0x4c4b40",
+      gasPrice: "0x0",
+      value: "0x0",
+      data: calldata,
+    };
+
+    console.log("tx: ", replayTx)
+
+    const result = await jsonRpcCall("http://62.171.133.46:54100", "eth_call", [
+      replayTx,
+      "0x6dde3",
+    ]);
+
+    console.log(result);
+  } catch (e: unknown) {
+    const err = e as EthereumCallError;
+
+    console.log(err);
+
+    let revertReason = BlockRewardHbbft.interface.parseError(err.data as any);
+    console.log("Revert reason: ", revertReason);
+  }
+}
+
+async function jsonRpcCall(
+  url: string,
+  method: string,
+  params: any[] = [],
+  id: number | string = 1,
+): Promise<JsonRpcResponse> {
+  const payload: JsonRpcRequest = {
+    jsonrpc: "2.0",
+    method: method,
+    params: params,
+    id: id,
+  };
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const jsonResponse: JsonRpcResponse = await response.json();
+
+  // Handle errors if they exist
+  if (jsonResponse.error) {
+    throw new EthereumCallError({
+      _code: jsonResponse.error.code,
+      _message: jsonResponse.error.message,
+      _data: jsonResponse.error.data,
+    });
+  }
+
+  return jsonResponse;
+}
+
+triggerReward()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
**Bug fixes:**

- Update `governancePotNominator` and `governancePotDenominator` values to match allowed range from `ValueGuards` [10, 20];
- Fix potential loss of undistributed epoch rewards in `_distributeRewards` if there were no rewarded validators;
- `earlyEpochEnd` flag corner cases handling. 

**Improvements:**

- Increase `BlockReward` contract tests coverage;
- Emit event on early epoch end notification receive.

