### PR TITLE
ValueGuards contract refactoring and tests

### DIFF
--- a/contracts/BlockRewardHbbft.sol
+++ b/contracts/BlockRewardHbbft.sol
@@ -103,6 +103,8 @@ contract BlockRewardHbbft is
 
     event EarlyEpochEndNotificationReceived();
 
+    event SetGovernancePotShareNominator(uint256 value);
+
     error ZeroPayoutFraction();
 
     // ============================================== Modifiers =======================================================
@@ -164,13 +166,13 @@ contract BlockRewardHbbft is
         governancePotShareDenominator = 100;
 
         uint256[] memory governancePotShareNominatorParams = new uint256[](11);
-        for (uint256 i = 0; i < governancePotShareNominatorParams.length; i++) {
+        for (uint256 i = 0; i < governancePotShareNominatorParams.length; ++i) {
             governancePotShareNominatorParams[i] = 10 + i;
         }
 
-        initAllowedChangeableParameter(
-            "setGovernancePotShareNominator(uint256)",
-            "governancePotShareNominator()",
+        __initAllowedChangeableParameter(
+            this.setGovernancePotShareNominator.selector,
+            this.governancePotShareNominator.selector,
             governancePotShareNominatorParams
         );
     }
@@ -272,11 +274,15 @@ contract BlockRewardHbbft is
      * Requirements:
      * - Only the contract owner can call this function.
      * - The _shareNominator value must be within the allowed range.
+     * 
+     * Emits a {SetGovernancePotShareNominator} event.
      */
     function setGovernancePotShareNominator(
         uint256 _shareNominator
-    ) public onlyOwner withinAllowedRange(_shareNominator) {
+    ) external onlyOwner withinAllowedRange(_shareNominator) {
         governancePotShareNominator = _shareNominator;
+
+        emit SetGovernancePotShareNominator(_shareNominator);
     }
 
     // =============================================== Getters ========================================================

--- a/contracts/StakingHbbft.sol
+++ b/contracts/StakingHbbft.sol
@@ -376,9 +376,9 @@ contract StakingHbbft is Initializable, OwnableUpgradeable, ReentrancyGuardUpgra
         delegatorMinStakeAllowedParams[3] = 200 ether;
         delegatorMinStakeAllowedParams[4] = 250 ether;
 
-        initAllowedChangeableParameter(
-            "setDelegatorMinStake(uint256)",
-            "delegatorMinStake()",
+        __initAllowedChangeableParameter(
+            this.setDelegatorMinStake.selector,
+            this.delegatorMinStake.selector,
             delegatorMinStakeAllowedParams
         );
 
@@ -417,13 +417,12 @@ contract StakingHbbft is Initializable, OwnableUpgradeable, ReentrancyGuardUpgra
      * Requirements:
      * - Only the contract owner can call this function.
      * - The stake amount must be within the allowed range.
+     *
+     * Emits a {SetDelegatorMinStake} event.
      */
-    function setDelegatorMinStake(uint256 _minStake)
-        public
-        onlyOwner
-        withinAllowedRange(_minStake)
-    {
+    function setDelegatorMinStake(uint256 _minStake) external onlyOwner withinAllowedRange(_minStake) {
         delegatorMinStake = _minStake;
+
         emit SetDelegatorMinStake(_minStake);
     }
 

--- a/contracts/TxPermissionHbbft.sol
+++ b/contracts/TxPermissionHbbft.sol
@@ -144,7 +144,7 @@ contract TxPermissionHbbft is Initializable, OwnableUpgradeable, ITxPermission, 
 
         __Ownable_init(_contractOwner);
 
-        for (uint256 i = 0; i < _allowed.length; i++) {
+        for (uint256 i = 0; i < _allowed.length; ++i) {
             _addAllowedSender(_allowed[i]);
         }
 
@@ -168,21 +168,22 @@ contract TxPermissionHbbft is Initializable, OwnableUpgradeable, ITxPermission, 
         minGasPriceAllowedParams[9] = 8 gwei;
         minGasPriceAllowedParams[10] = 10 gwei;
 
-        initAllowedChangeableParameter("setMinimumGasPrice(uint256)", "minimumGasPrice()", minGasPriceAllowedParams);
+        __initAllowedChangeableParameter(
+            this.setMinimumGasPrice.selector,
+            this.minimumGasPrice.selector,
+            minGasPriceAllowedParams
+        );
 
         uint256[] memory blockGasLimitAllowedParams = new uint256[](10);
-        blockGasLimitAllowedParams[0] = 100_000_000;
-        blockGasLimitAllowedParams[1] = 200_000_000;
-        blockGasLimitAllowedParams[2] = 300_000_000;
-        blockGasLimitAllowedParams[3] = 400_000_000;
-        blockGasLimitAllowedParams[4] = 500_000_000;
-        blockGasLimitAllowedParams[5] = 600_000_000;
-        blockGasLimitAllowedParams[6] = 700_000_000;
-        blockGasLimitAllowedParams[7] = 800_000_000;
-        blockGasLimitAllowedParams[8] = 900_000_000;
-        blockGasLimitAllowedParams[9] = 1000_000_000;
+        for (uint256 i = 0; i < blockGasLimitAllowedParams.length; ++i) {
+            blockGasLimitAllowedParams[i] = (i + 1) * 1e8;
+        }
 
-        initAllowedChangeableParameter("setBlockGasLimit(uint256)", "blockGasLimit()", blockGasLimitAllowedParams);
+        __initAllowedChangeableParameter(
+            this.setBlockGasLimit.selector,
+            this.blockGasLimit.selector,
+            blockGasLimitAllowedParams
+        );
     }
 
     /// @dev Adds the address for which transactions of any type must be allowed.
@@ -222,6 +223,7 @@ contract TxPermissionHbbft is Initializable, OwnableUpgradeable, ITxPermission, 
     /// before submitting it as contribution.
     /// The limit can be changed by the owner (typical the DAO)
     /// @param _value The new minimum gas price.
+    /// Emits a {GasPriceChanged} event.
     function setMinimumGasPrice(uint256 _value) public onlyOwner withinAllowedRange(_value) {
         // param value validation is done in the {ValueGuards-withinAllowedRange} modifier
         minimumGasPrice = _value;
@@ -231,6 +233,7 @@ contract TxPermissionHbbft is Initializable, OwnableUpgradeable, ITxPermission, 
 
     /// @dev set's the block gas limit.
     /// IN HBBFT, there must be consens about the block gas limit.
+    /// Emits a {BlockGasLimitChanged} event.
     function setBlockGasLimit(uint256 _value) public onlyOwner withinAllowedRange(_value) {
         // param value validation is done in the {ValueGuards-withinAllowedRange} modifier
         blockGasLimit = _value;

--- a/contracts/mockContracts/ValueGuardsMock.sol
+++ b/contracts/mockContracts/ValueGuardsMock.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache 2.0
+pragma solidity =0.8.25;
+
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+import { ValueGuards } from "../ValueGuards.sol";
+
+
+contract ValueGuardsMock is Initializable, OwnableUpgradeable, ValueGuards {
+    uint256 public valueA;
+    uint256 private valueB;
+
+    uint256 public valueC;
+
+    event SetValueA(uint256 _val);
+    event SetValueB(uint256 _val);
+
+    function initialize(
+        uint256 _initialValueA,
+        uint256 _initialValueB,
+        uint256[] memory allowedRangeValueA,
+        uint256[] memory allowedRangeValueB
+    ) external initializer {
+        __Ownable_init(msg.sender);
+
+        __initAllowedChangeableParameter(
+            this.setValueA.selector,
+            this.valueA.selector,
+            allowedRangeValueA
+        );
+
+        __initAllowedChangeableParameter(
+            this.setValueB.selector,
+            this.getValueB.selector,
+            allowedRangeValueB
+        );
+
+        valueA = _initialValueA;
+        valueB = _initialValueB;
+    }
+
+    function setValueA(uint256 _val) external onlyOwner withinAllowedRange(_val) {
+        valueA = _val;
+
+        emit SetValueA(_val);
+    }
+
+    function setValueB(uint256 _val) external onlyOwner withinAllowedRange(_val) {
+        valueB = _val;
+
+        emit SetValueB(_val);
+    }
+
+    function setUnprotectedValueC(uint256 _val) external onlyOwner {
+        valueC = _val;
+    }
+
+    function getValueB() external view returns (uint256) {
+        return valueB;
+    }
+
+    function initAllowedChangableParam(bytes4 setter, bytes4 getter, uint256[] memory params) external {
+        __initAllowedChangeableParameter(setter, getter, params);
+    }
+}

--- a/test/ValueGuards.ts
+++ b/test/ValueGuards.ts
@@ -1,0 +1,313 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+
+import { ValueGuardsMock } from "../src/types";
+
+const EmptyBytes4 = ethers.hexlify(ethers.getBytes(ethers.ZeroHash).slice(0, 4));
+
+describe('ValueGuards contract', () => {
+    let accounts: HardhatEthersSigner[];
+    let owner: HardhatEthersSigner;
+
+    const AllowedRangeValueA = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+    const AllowedRangeValueB = [10, 15, 20, 25, 30, 35, 40, 45, 50];
+    const InitialValueA = 0;
+    const InitialValueB = 30;
+
+    async function deployContract() {
+        const valueGuardsFactory = await ethers.getContractFactory("ValueGuardsMock");
+        const valueGuards = await upgrades.deployProxy(
+            valueGuardsFactory,
+            [InitialValueA, InitialValueB, AllowedRangeValueA, AllowedRangeValueB],
+            { initializer: 'initialize' }
+        ) as unknown as ValueGuardsMock;
+
+        await valueGuards.waitForDeployment();
+
+        return { valueGuards };
+    }
+
+    before(async function () {
+        [owner, ...accounts] = await ethers.getSigners();
+    });
+
+    describe('Initializer', async () => {
+        it("should set allowed value ranges on initialization", async () => {
+            const valueGuardsFactory = await ethers.getContractFactory("ValueGuardsMock");
+
+            const setterA = valueGuardsFactory.interface.getFunction("setValueA")!.selector;
+            const setterB = valueGuardsFactory.interface.getFunction("setValueB")!.selector;
+
+            const getterA = valueGuardsFactory.interface.getFunction("valueA")!.selector;
+            const getterB = valueGuardsFactory.interface.getFunction("getValueB")!.selector;
+
+            const valueGuards = await upgrades.deployProxy(
+                valueGuardsFactory,
+                { initializer: false },
+            ) as unknown as ValueGuardsMock;
+
+            await valueGuards.waitForDeployment();
+
+            await expect(valueGuards.initialize(
+                InitialValueA,
+                InitialValueB,
+                AllowedRangeValueA,
+                AllowedRangeValueB,
+            ))
+                .to.emit(valueGuards, "SetChangeableParameter").withArgs(setterA, getterA, AllowedRangeValueA)
+                .to.emit(valueGuards, "SetChangeableParameter").withArgs(setterB, getterB, AllowedRangeValueB);
+        });
+
+        it("should not allow value range initialization outside of initializer", async () => {
+            const { valueGuards } = await loadFixture(deployContract);
+
+            const setter = valueGuards.interface.getFunction("setValueA").selector;
+            const getter = valueGuards.interface.getFunction("valueA").selector;
+
+            await expect(valueGuards.initAllowedChangableParam(setter, getter, AllowedRangeValueA))
+                .to.be.revertedWithCustomError(valueGuards, "NotInitializing");
+        });
+    });
+
+    describe('setAllowedChangeableParameter', async () => {
+        it("should be callable only by contract owner", async () => {
+            const { valueGuards } = await loadFixture(deployContract);
+
+            const caller = accounts[5];
+
+            const setter = valueGuards.interface.getFunction("setValueA").selector;
+            const getter = valueGuards.interface.getFunction("valueA").selector;
+
+            await expect(valueGuards.connect(caller).setAllowedChangeableParameter(setter, getter, []))
+                .to.be.revertedWithCustomError(valueGuards, "OwnableUnauthorizedAccount")
+                .withArgs(caller.address);
+        });
+
+        it("should set allowed changeable parameter and emit event", async () => {
+            const { valueGuards } = await loadFixture(deployContract);
+
+            const setter = ethers.hexlify(ethers.getBytes(ethers.id("setSomeVal(uint256)")).slice(0, 4));
+            const getter = ethers.hexlify(ethers.getBytes(ethers.id("getSomeVal()")).slice(0, 4));
+            const allowedRange = [1, 100];
+
+            await expect(valueGuards.connect(owner).setAllowedChangeableParameter(setter, getter, allowedRange))
+                .to.emit(valueGuards, "SetChangeableParameter")
+                .withArgs(setter, getter, allowedRange);
+
+            const actualValues = await valueGuards.getAllowedParamsRangeWithSelector(setter);
+
+            expect(actualValues.getter).to.eq(getter);
+            expect(actualValues.range).to.deep.eq(allowedRange);
+        });
+    });
+
+    describe('removeAllowedChangeableParameter', async () => {
+        it("should be callable only by contract owner", async () => {
+            const { valueGuards } = await loadFixture(deployContract);
+
+            const caller = accounts[5];
+            const setter = valueGuards.interface.getFunction("setValueA").selector;
+
+            await expect(valueGuards.connect(caller).removeAllowedChangeableParameter(setter))
+                .to.be.revertedWithCustomError(valueGuards, "OwnableUnauthorizedAccount")
+                .withArgs(caller.address);
+        });
+
+        it("should remove allowed changeable parameter and emit event", async () => {
+            const { valueGuards } = await loadFixture(deployContract);
+
+            const setter = ethers.hexlify(ethers.getBytes(ethers.id("setSomeVal(uint256)")).slice(0, 4));
+            const getter = ethers.hexlify(ethers.getBytes(ethers.id("getSomeVal()")).slice(0, 4));
+            const allowedRange = [1, 100];
+
+            expect(await valueGuards.connect(owner).setAllowedChangeableParameter(setter, getter, allowedRange));
+
+            let actualValues = await valueGuards.getAllowedParamsRangeWithSelector(setter);
+            expect(actualValues.getter).to.eq(getter);
+            expect(actualValues.range).to.deep.eq(allowedRange);
+
+            await expect(valueGuards.removeAllowedChangeableParameter(setter))
+                .to.emit(valueGuards, "RemoveChangeableParameter")
+                .withArgs(setter);
+
+            actualValues = await valueGuards.getAllowedParamsRangeWithSelector(setter);
+            expect(actualValues.getter).to.eq(EmptyBytes4);
+            expect(actualValues.range).to.be.empty;
+        });
+    });
+
+    describe('getAllowedParamsRange', async () => {
+        it("should get by function sighash", async() => {
+            const { valueGuards } = await loadFixture(deployContract);
+
+            const sighash = valueGuards.interface.getFunction("setValueA").format("sighash");
+            const getter = valueGuards.interface.getFunction("valueA").selector;
+
+            const result = await valueGuards.getAllowedParamsRange(sighash);
+
+            expect(result.getter).to.eq(getter);
+            expect(result.range).to.deep.eq(AllowedRangeValueA);
+        });
+
+        it("should get by function selector", async() => {
+            const { valueGuards } = await loadFixture(deployContract);
+
+            const selector = valueGuards.interface.getFunction("setValueA").selector;
+            const getter = valueGuards.interface.getFunction("valueA").selector;
+
+            const result = await valueGuards.getAllowedParamsRangeWithSelector(selector);
+
+            expect(result.getter).to.eq(getter);
+            expect(result.range).to.deep.eq(AllowedRangeValueA);
+        });
+    });
+
+    describe('isWithinAllowedRange', async () => {
+        const TestCases = [
+            {
+                initialValue: 2,
+                allowedRange: [1, 2, 3],
+                expectedResult: [true, false, true],
+            },
+            {
+                initialValue: 1,
+                allowedRange: [1, 2, 3],
+                expectedResult: [true, true, false],
+            },
+            {
+                initialValue: 3,
+                allowedRange: [1, 2, 3],
+                expectedResult: [false, true, true],
+            },
+            {
+                initialValue: 0,
+                allowedRange: [1, 2, 3],
+                expectedResult: [false, false, false],
+            },
+            {
+                initialValue: 10,
+                allowedRange: [1, 2, 3],
+                expectedResult: [false, false, false],
+            },
+            {
+                initialValue: 10,
+                allowedRange: [0, 1, 5, 10, 11, 15],
+                expectedResult: [false, false, true, false, true, false],
+            },
+            {
+                initialValue: 0,
+                allowedRange: [0, 1, 5, 10, 11, 15],
+                expectedResult: [true, true, false, false, false, false],
+            },
+        ]
+
+        it("should return false for unknown selector", async () => {
+            const { valueGuards } = await loadFixture(deployContract);
+
+            const setter = ethers.hexlify(ethers.getBytes(ethers.id("setSomeVal(uint256)")).slice(0, 4));
+
+            expect(await valueGuards.isWithinAllowedRange(setter, 0)).to.be.false;
+        });
+
+        it("should revert if getter function not exist", async () => {
+            const { valueGuards } = await loadFixture(deployContract);
+
+            const setter = ethers.hexlify(ethers.getBytes(ethers.id("setSomeVal(uint256)")).slice(0, 4));
+            const getter = EmptyBytes4;
+            const allowedRange = [1, 100];
+
+            expect(await valueGuards.connect(owner).setAllowedChangeableParameter(setter, getter, allowedRange));
+
+            await expect(valueGuards.isWithinAllowedRange(setter, 1))
+                .to.be.revertedWithCustomError(valueGuards, "GetterCallFailed");
+        });
+
+        TestCases.forEach((testCase, index) => {
+            it(`should get is allowed, test #${index + 1}`, async function () {
+                const { valueGuards } = await loadFixture(deployContract);
+
+                const setter = valueGuards.interface.getFunction("setUnprotectedValueC").selector;
+                const getter = valueGuards.interface.getFunction("valueC").selector;
+
+                expect(await valueGuards.connect(owner).setUnprotectedValueC(testCase.initialValue));
+                expect(await valueGuards.connect(owner).setAllowedChangeableParameter(setter, getter, testCase.allowedRange));
+
+                for (let i = 0; i < testCase.allowedRange.length; ++i) {
+                    expect(
+                        await valueGuards.isWithinAllowedRange(setter, testCase.allowedRange[i])
+                    ).to.eq(testCase.expectedResult[i])
+                }
+            });
+        });
+    });
+
+    describe('withinAllowedRange modifier', async() => {
+        it("should work for public storage variable getter func", async () => {
+            const { valueGuards } = await loadFixture(deployContract);
+
+            // AllowedRangeValueA = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+            // InitialValueA = 0
+            const newValue = 1;
+
+            await expect(valueGuards.setValueA(newValue))
+                .to.emit(valueGuards, "SetValueA")
+                .withArgs(newValue);
+
+            expect(await valueGuards.valueA()).to.eq(newValue);
+        });
+
+        it("should work for external getter function", async () => {
+            const { valueGuards } = await loadFixture(deployContract);
+
+            // AllowedRangeValueB = [10, 15, 20, 25, 30, 35, 40, 45, 50];
+            // InitialValueB = 30
+            const newValue = 25;
+
+            await expect(valueGuards.setValueB(newValue))
+                .to.emit(valueGuards, "SetValueB")
+                .withArgs(newValue);
+
+            expect(await valueGuards.getValueB()).to.eq(newValue);
+        });
+
+        it("should change value step by step", async () => {
+            const { valueGuards } = await loadFixture(deployContract);
+
+            const idx = AllowedRangeValueB.indexOf(InitialValueB);
+
+            for (let i = idx + 1; i < AllowedRangeValueB.length; ++i) {
+                const newValue = AllowedRangeValueB[i];
+
+                await expect(valueGuards.setValueB(newValue))
+                    .to.emit(valueGuards, "SetValueB")
+                    .withArgs(newValue);
+
+                expect(await valueGuards.getValueB()).to.eq(newValue);
+            }
+        });
+
+        it("should not allow skipping steps", async () => {
+            const { valueGuards } = await loadFixture(deployContract);
+
+            const idx = AllowedRangeValueB.indexOf(InitialValueB);
+
+            // 1 step forward
+            let newValue = AllowedRangeValueB[idx + 1];
+
+            await expect(valueGuards.setValueB(newValue))
+                .to.emit(valueGuards, "SetValueB")
+                .withArgs(newValue);
+
+            expect(await valueGuards.getValueB()).to.eq(newValue);
+
+            // 2 steps back
+            newValue = AllowedRangeValueB[idx - 1];
+
+            await expect(valueGuards.setValueB(newValue))
+                .to.be.revertedWithCustomError(valueGuards, "NewValueOutOfRange")
+                .withArgs(newValue);
+        });
+    });
+});


### PR DESCRIPTION
This pull request includes:

1. Make `ValueGuards` contract `abstract` to explicitly show that it should not be deployed directly;
2. Make `initAllowedChangeableParameter` function internal;
3. `ValueGuards` contract unit tests;
4. Switch to function selectors instead of full string signature to initialize allowed changeable params in `ValueGuards` contract to make it simpler and more straightforward:

Before
```solidity
initAllowedChangeableParameter(
    "setGovernancePotShareNominator(uint256)",
    "governancePotShareNominator()",
    governancePotShareNominatorParams
);
``` 
After
```solidity
initAllowedChangeableParameter(
    this.setGovernancePotShareNominator.selector,
    this.governancePotShareNominator.selector,
    governancePotShareNominatorParams
);
``` 


