### PR TITLE
Remove unwanted setters

### DIFF
--- a/contracts/BlockRewardHbbft.sol
+++ b/contracts/BlockRewardHbbft.sol
@@ -89,23 +89,9 @@ contract BlockRewardHbbft is
     /// @param rewards The amount minted and distributed among the validators.
     event CoinsRewarded(uint256 rewards);
 
-    /// @dev Emitted by the `setConnectivityTracker` function.
-    /// @param _connectivityTracker New ConnectivityTracker contract address.
-    event SetConnectivityTracker(address _connectivityTracker);
-
-    /// @dev Emitted by the `setdeltaPotPayoutFraction` function.
-    /// @param _fraction New delta pot payout fraction value.
-    event SetDeltaPotPayoutFraction(uint256 _fraction);
-
-    /// @dev Emitted by the `setReinsertPotPayoutFraction` function.
-    /// @param _fraction New reinsert pot payout fraction value.
-    event SetReinsertPotPayoutFraction(uint256 _fraction);
-
     event EarlyEpochEndNotificationReceived();
 
     event SetGovernancePotShareNominator(uint256 value);
-
-    error ZeroPayoutFraction();
 
     // ============================================== Modifiers =======================================================
 
@@ -195,45 +181,6 @@ contract BlockRewardHbbft is
     /// everyone is welcomed to pile up the reinsert pot.
     function addToReinsertPot() external payable {
         reinsertPot += msg.value;
-    }
-
-    /// @dev set the delta pot payout fraction.
-    /// every epoch,
-    /// a fraction of the delta pot is payed out.
-    /// Only theOwner, the DAO is allowed to set the delta pot payout fraction.
-    function setdeltaPotPayoutFraction(uint256 _value) external onlyOwner {
-        if (_value == 0) {
-            revert ZeroPayoutFraction();
-        }
-
-        deltaPotPayoutFraction = _value;
-
-        emit SetDeltaPotPayoutFraction(_value);
-    }
-
-    /// @dev set the reinsert pot payout fraction.
-    /// every epoch,
-    /// a fraction of the reinsert pot is payed out.
-    /// (same logic than in the reinsert pot.)
-    /// Only theOwner, the DAO is allowed to set the reinsert pot payout fraction.
-    function setReinsertPotPayoutFraction(uint256 _value) external onlyOwner {
-        if (_value == 0) {
-            revert ZeroPayoutFraction();
-        }
-
-        reinsertPotPayoutFraction = _value;
-
-        emit SetReinsertPotPayoutFraction(_value);
-    }
-
-    function setConnectivityTracker(address _connectivityTracker) external onlyOwner {
-        if (_connectivityTracker == address(0)) {
-            revert ZeroAddress();
-        }
-
-        connectivityTracker = IConnectivityTrackerHbbft(_connectivityTracker);
-
-        emit SetConnectivityTracker(_connectivityTracker);
     }
 
     /// @dev Notify block reward contract, that current epoch must be closed earlier.

--- a/contracts/BonusScoreSystem.sol
+++ b/contracts/BonusScoreSystem.sol
@@ -48,21 +48,6 @@ contract BonusScoreSystem is Initializable, OwnableUpgradeable, ReentrancyGuardU
     /// @param value New scoring factor bonus/penalty value.
     event UpdateScoringFactor(ScoringFactor indexed factor, uint256 value);
 
-    /// @dev Emitted by the `setStakingContract` function when StakingHbbft contract address changes
-    /// @param _staking New StakingHbbft contract address
-    event SetStakingContract(address indexed _staking);
-
-    /// @dev Emitted by the `setValidatorSetContract` function when ValidatorSetHbbft contract address changes
-    /// @param _validatorSet New ValidatorSetHbbft contract address
-    event SetValidatorSetContract(address indexed _validatorSet);
-
-    /// @dev Emitted by the `setConnectivityTrackerContract` function
-    /// when ConnectivityTrackerHbbft contract address changes
-    /// @param _connectivityTracker New ConnectivityTrackerHbbft contract address
-    event SetConnectivityTrackerContract(address indexed _connectivityTracker);
-
-    error ZeroFactorValue();
-    error InvalidScoringFactor();
     error InvalidIntervalStartTimestamp();
 
     modifier onlyValidatorSet() {
@@ -75,13 +60,6 @@ contract BonusScoreSystem is Initializable, OwnableUpgradeable, ReentrancyGuardU
     modifier onlyConnectivityTracker() {
         if (msg.sender != connectivityTracker) {
             revert Unauthorized();
-        }
-        _;
-    }
-
-    modifier validAddress(address _address) {
-        if (_address == address(0)) {
-            revert ZeroAddress();
         }
         _;
     }
@@ -114,35 +92,6 @@ contract BonusScoreSystem is Initializable, OwnableUpgradeable, ReentrancyGuardU
         stakingHbbft = IStakingHbbft(_stakingHbbft);
 
         _setInitialScoringFactors();
-    }
-
-    function setStakingContract(address _staking) external onlyOwner validAddress(_staking) {
-        stakingHbbft = IStakingHbbft(_staking);
-
-        emit SetStakingContract(_staking);
-    }
-
-    function setValidatorSetContract(address _validatorSet) external onlyOwner validAddress(_validatorSet) {
-        validatorSetHbbft = _validatorSet;
-
-        emit SetValidatorSetContract(_validatorSet);
-    }
-
-    function setConnectivityTrackerContract(address _address) external onlyOwner validAddress(_address) {
-        connectivityTracker = _address;
-
-        emit SetConnectivityTrackerContract(_address);
-    }
-
-    /// TODO: Define value guards.
-    function updateScoringFactor(ScoringFactor factor, uint256 value) external onlyOwner {
-        if (value == 0) {
-            revert ZeroFactorValue();
-        }
-
-        _factors[factor] = value;
-
-        emit UpdateScoringFactor(factor, value);
     }
 
     /// @dev Reward a validator who could not get into the current set, but was available.

--- a/contracts/ConnectivityTrackerHbbft.sol
+++ b/contracts/ConnectivityTrackerHbbft.sol
@@ -81,12 +81,6 @@ contract ConnectivityTrackerHbbft is Initializable, OwnableUpgradeable, IConnect
     event SetReportDisallowPeriod(uint256 _reportDisallowPeriodSeconds);
 
     /**
-     * @dev Emitted by the {setEarlyEpochEndToleranceLevel} function.
-     * @param _level New early epoch end tolerance level.
-     */
-    event SetEarlyEpochEndToleranceLevel(uint256 _level);
-
-    /**
      * @dev Emitted when `validator` was reported by `reporter` for lost connection at block `blockNumber`.
      * @param reporter Reporting validator address.
      * @param validator Address of the validator with which the connection was lost.
@@ -191,21 +185,6 @@ contract ConnectivityTrackerHbbft is Initializable, OwnableUpgradeable, IConnect
         reportDisallowPeriod = _reportDisallowPeriodSeconds;
 
         emit SetReportDisallowPeriod(_reportDisallowPeriodSeconds);
-    }
-
-    /**
-     * @dev This function sets the early epoch end tolerance level.
-     * Can only be called by contract owner.
-     * @param _level New early epoch end tolerance level.
-     *
-     * Emits a {SetEarlyEpochEndToleranceLevel} event.
-     */
-    function setEarlyEpochEndToleranceLevel(uint256 _level) external onlyOwner {
-        earlyEpochEndToleranceLevel = _level;
-
-        _decideEarlyEpochEndNeeded(currentEpoch());
-
-        emit SetEarlyEpochEndToleranceLevel(_level);
     }
 
     /**

--- a/contracts/StakingHbbft.sol
+++ b/contracts/StakingHbbft.sol
@@ -260,12 +260,6 @@ contract StakingHbbft is Initializable, OwnableUpgradeable, ReentrancyGuardUpgra
      */
     event SetDelegatorMinStake(uint256 minStake);
 
-    /**
-     * @dev Emitted when the BonusScoreSystem contract address is changed.
-     * @param _address BonusScoreSystem contract address.
-     */
-    event SetBonusScoreContract(address _address);
-
     // ============================================== Errors =======================================================
     error CannotClaimWithdrawOrderYet(address pool, address staker);
     error OnlyOncePerEpoch(uint256 _epoch);
@@ -471,16 +465,6 @@ contract StakingHbbft is Initializable, OwnableUpgradeable, ReentrancyGuardUpgra
     ) external onlyValidatorSetContract {
         poolInfo[_validatorAddress].internetAddress = _ip;
         poolInfo[_validatorAddress].port = _port;
-    }
-
-    function setBonusScoreContract(address _bonusScoreContract) external onlyOwner {
-        if (_bonusScoreContract == address(0)) {
-            revert ZeroAddress();
-        }
-
-        bonusScoreContract = IBonusScoreSystem(_bonusScoreContract);
-
-        emit SetBonusScoreContract(_bonusScoreContract);
     }
 
     /// @dev Increments the serial number of the current staking epoch.

--- a/contracts/StakingHbbft.sol
+++ b/contracts/StakingHbbft.sol
@@ -415,22 +415,6 @@ contract StakingHbbft is Initializable, OwnableUpgradeable, ReentrancyGuardUpgra
         stakingTransitionTimeframeLength = stakingParams._stakingTransitionTimeframeLength;
     }
 
-    function setStakingTransitionTimeframeLength(uint256 _value) external onlyOwner {
-        if (_value <= 10 || _value >= stakingFixedEpochDuration) {
-            revert InvalidStakingTransitionTimeframe();
-        }
-
-        stakingTransitionTimeframeLength = _value;
-    }
-
-    function setStakingFixedEpochDuration(uint256 _value) external onlyOwner {
-        if (_value <= stakingTransitionTimeframeLength) {
-            revert InvalidStakingFixedEpochDuration();
-        }
-
-        stakingFixedEpochDuration = _value;
-    }
-
     /**
      * @dev Sets the minimum stake required for delegators.
      * @param _minStake The new minimum stake amount.

--- a/contracts/TxPermissionHbbft.sol
+++ b/contracts/TxPermissionHbbft.sol
@@ -85,16 +85,6 @@ contract TxPermissionHbbft is Initializable, OwnableUpgradeable, ITxPermission, 
 
     // ============================================== Events ==========================================================
 
-    event GasPriceChanged(uint256 _value);
-    event BlockGasLimitChanged(uint256 _value);
-    event SetConnectivityTracker(address _value);
-
-    error InvalidMinGasPrice();
-    error InvalidBlockGasLimit();
-    error SenderNotAllowed();
-    error AlreadyExist(address _value);
-    error NotExist(address _value);
-
     /**
      * @dev Emitted when the minimum gas price is updated.
      * @param _minGasPrice The new minimum gas price.
@@ -106,6 +96,16 @@ contract TxPermissionHbbft is Initializable, OwnableUpgradeable, ITxPermission, 
      * @param _blockGasLimit The new block gas limit.
      */
     event SetBlockGasLimit(uint256 _blockGasLimit);
+
+    event AddAllowedSender(address indexed _sender);
+
+    event RemoveAllowedSender(address indexed _sender);
+
+    error InvalidMinGasPrice();
+    error InvalidBlockGasLimit();
+    error SenderNotAllowed();
+    error AlreadyExist(address _value);
+    error NotExist(address _value);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -213,6 +213,8 @@ contract TxPermissionHbbft is Initializable, OwnableUpgradeable, ITxPermission, 
         }
 
         isSenderAllowed[_sender] = false;
+
+        emit RemoveAllowedSender(_sender);
     }
 
     /// @dev set's the minimum gas price that is allowed by non-service transactions.
@@ -228,7 +230,7 @@ contract TxPermissionHbbft is Initializable, OwnableUpgradeable, ITxPermission, 
         // param value validation is done in the {ValueGuards-withinAllowedRange} modifier
         minimumGasPrice = _value;
 
-        emit GasPriceChanged(_value);
+        emit SetMinimumGasPrice(_value);
     }
 
     /// @dev set's the block gas limit.
@@ -238,17 +240,7 @@ contract TxPermissionHbbft is Initializable, OwnableUpgradeable, ITxPermission, 
         // param value validation is done in the {ValueGuards-withinAllowedRange} modifier
         blockGasLimit = _value;
 
-        emit BlockGasLimitChanged(_value);
-    }
-
-    function setConnectivityTracker(address _connectivityTracker) external onlyOwner {
-        if (_connectivityTracker == address(0)) {
-            revert ZeroAddress();
-        }
-
-        connectivityTracker = IConnectivityTrackerHbbft(_connectivityTracker);
-
-        emit SetConnectivityTracker(_connectivityTracker);
+        emit SetBlockGasLimit(_value);
     }
 
     // =============================================== Getters ========================================================
@@ -451,6 +443,8 @@ contract TxPermissionHbbft is Initializable, OwnableUpgradeable, ITxPermission, 
 
         _allowedSenders.push(_sender);
         isSenderAllowed[_sender] = true;
+
+        emit AddAllowedSender(_sender);
     }
 
     /// @dev retrieves a UInt256 slice of a bytes array on a specific location

--- a/contracts/ValidatorSetHbbft.sol
+++ b/contracts/ValidatorSetHbbft.sol
@@ -83,11 +83,6 @@ contract ValidatorSetHbbft is Initializable, OwnableUpgradeable, IValidatorSetHb
     /// validators reporter him as disconnected.
     event ValidatorUnavailable(address validator, uint256 timestamp);
 
-    event SetMaxValidators(uint256 _count);
-    event SetValidatorInactivityThreshold(uint256 _value);
-    event SetBonusScoreContract(address _address);
-    event SetConnectivityTrackerContract(address _address);
-
     error AnnounceBlockNumberTooOld();
     error CantAnnounceAvailability();
     error EpochNotYetzFinished();
@@ -132,13 +127,6 @@ contract ValidatorSetHbbft is Initializable, OwnableUpgradeable, IValidatorSetHb
         // Prevents initialization of implementation contract
         _disableInitializers();
     }
-
-    // function getInfo()
-    // public
-    // view
-    // returns (address sender, address admin) {
-    //     return (msg.sender, _admin());
-    // }
 
     // =============================================== Setters ========================================================
 
@@ -224,44 +212,6 @@ contract ValidatorSetHbbft is Initializable, OwnableUpgradeable, IValidatorSetHb
     /// Automatically called by the `BlockRewardHbbft.reward` function at the latest block of the staking epoch.
     function newValidatorSet() external onlyBlockRewardContract {
         _newValidatorSet(new address[](0));
-    }
-
-    /// @dev Inactive validators and their stakers loose there stake after a certain period of time.
-    /// This function defines the lenght of this time window. 
-    /// @param _seconds new value in seconds. 
-    function setValidatorInactivityThreshold(uint256 _seconds) external onlyOwner {
-        
-        // chosen abritary minimum value of a week.
-        // if you want smaller values for tests,
-        // the contract can be deployed with a smaller value
-        // (no restriction there)
-        if (_seconds < 1 weeks) {
-            revert InvalidInactivityThreshold();
-        }
-
-        validatorInactivityThreshold = _seconds;
-
-        emit SetValidatorInactivityThreshold(_seconds);
-    }
-
-    function setBonusScoreSystemAddress(address _address) external onlyOwner {
-        if (_address == address(0)) {
-            revert ZeroAddress();
-        }
-
-        bonusScoreSystem = IBonusScoreSystem(_address);
-
-        emit SetBonusScoreContract(_address);
-    }
-
-    function setConnectivityTracker(address _address) external onlyOwner {
-        if (_address == address(0)) {
-            revert ZeroAddress();
-        }
-
-        connectivityTracker = _address;
-
-        emit SetConnectivityTrackerContract(_address);
     }
 
     /// @dev called by validators when a validator comes online after
@@ -442,12 +392,6 @@ contract ValidatorSetHbbft is Initializable, OwnableUpgradeable, IValidatorSetHb
     /// and should never be used as a pool before.
     function setStakingAddress(address _miningAddress, address _stakingAddress) external onlyStakingContract {
         _setStakingAddress(_miningAddress, _stakingAddress);
-    }
-
-    function setMaxValidators(uint256 _maxValidators) external onlyOwner {
-        maxValidators = _maxValidators;
-
-        emit SetMaxValidators(_maxValidators);
     }
 
     /// @dev set's the validators ip address.

--- a/contracts/mockContracts/BlockRewardHbbftMock.sol
+++ b/contracts/mockContracts/BlockRewardHbbftMock.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache 2.0
 pragma solidity =0.8.25;
 
+import { IConnectivityTrackerHbbft } from "../interfaces/IConnectivityTrackerHbbft.sol";
 import { BlockRewardHbbft } from "../BlockRewardHbbft.sol";
 
 contract BlockRewardHbbftMock is BlockRewardHbbft {
@@ -8,6 +9,10 @@ contract BlockRewardHbbftMock is BlockRewardHbbft {
 
     function sendCoins() external payable {
         return;
+    }
+
+    function setConnectivityTracker(address _connectivityTracker) external {
+        connectivityTracker = IConnectivityTrackerHbbft(_connectivityTracker);
     }
 
     function setGovernanceAddress(address _address) external {

--- a/contracts/mockContracts/ReentrancyAttacker.sol
+++ b/contracts/mockContracts/ReentrancyAttacker.sol
@@ -8,12 +8,12 @@ contract ReentrancyAttacker {
     uint256 public timeArgValue;
     bytes4 public funcId;
 
-    constructor(address _bonusScoreSystem) {
-        bonusScoreSystem = IBonusScoreSystem(_bonusScoreSystem);
-    }
-
     function setFuncId(bytes4 id) external {
         funcId = id;
+    }
+
+    function setBonusScoreContract(address _bonusScoreSystem) external {
+        bonusScoreSystem = IBonusScoreSystem(_bonusScoreSystem);
     }
 
     function attack(address mining, uint256 time) public {

--- a/contracts/mockContracts/StakingHbbftMock.sol
+++ b/contracts/mockContracts/StakingHbbftMock.sol
@@ -3,6 +3,7 @@ pragma solidity =0.8.25;
 
 import { StakingHbbft } from "../StakingHbbft.sol";
 import { IValidatorSetHbbft } from "../interfaces/IValidatorSetHbbft.sol";
+import { IBonusScoreSystem } from "../interfaces/IBonusScoreSystem.sol";
 import { Unauthorized } from "../lib/Errors.sol";
 
 contract StakingHbbftMock is StakingHbbft {
@@ -48,6 +49,10 @@ contract StakingHbbftMock is StakingHbbft {
 
     function setValidatorSetAddress(IValidatorSetHbbft _validatorSetAddress) public {
         validatorSetContract = _validatorSetAddress;
+    }
+
+    function setBonusScoreContract(address _bonusScoreContract) public {
+        bonusScoreContract = IBonusScoreSystem(_bonusScoreContract);
     }
 
     // =============================================== Getters ========================================

--- a/contracts/mockContracts/TxPermissionHbbftMock.sol
+++ b/contracts/mockContracts/TxPermissionHbbftMock.sol
@@ -3,6 +3,7 @@
 pragma solidity =0.8.25;
 
 import { IValidatorSetHbbft } from "../interfaces/IValidatorSetHbbft.sol";
+import { IConnectivityTrackerHbbft } from "../interfaces/IConnectivityTrackerHbbft.sol";
 import { TxPermissionHbbft } from "../TxPermissionHbbft.sol";
 
 contract MockStaking {
@@ -43,5 +44,9 @@ contract MockValidatorSet {
 contract TxPermissionHbbftMock is TxPermissionHbbft {
     function setValidatorSetContract(address _address) external {
         validatorSetContract = IValidatorSetHbbft(_address);
+    }
+
+    function setConnectivityTracker(address _connectivityTracker) external {
+        connectivityTracker = IConnectivityTrackerHbbft(_connectivityTracker);
     }
 }

--- a/contracts/mockContracts/ValidatorSetHbbftMock.sol
+++ b/contracts/mockContracts/ValidatorSetHbbftMock.sol
@@ -4,6 +4,7 @@ pragma solidity =0.8.25;
 import { ValidatorSetHbbft } from "../ValidatorSetHbbft.sol";
 import { IKeyGenHistory } from "../interfaces/IKeyGenHistory.sol";
 import { IStakingHbbft } from "../interfaces/IStakingHbbft.sol";
+import { IBonusScoreSystem } from "../interfaces/IBonusScoreSystem.sol";
 
 contract ValidatorSetHbbftMock is ValidatorSetHbbft {
     receive() external payable {}
@@ -24,6 +25,14 @@ contract ValidatorSetHbbftMock is ValidatorSetHbbft {
 
     function setKeyGenHistoryContract(address _address) public {
         keyGenHistoryContract = IKeyGenHistory(_address);
+    }
+
+    function setBonusScoreSystemAddress(address _address) public {
+        bonusScoreSystem = IBonusScoreSystem(_address);
+    }
+
+    function setConnectivityTracker(address _address) public {
+        connectivityTracker = _address;
     }
 
     function setValidatorAvailableSince(address _validator, uint256 _timestamp) public {

--- a/test/BlockRewardHbbft.ts
+++ b/test/BlockRewardHbbft.ts
@@ -466,62 +466,6 @@ describe('BlockRewardHbbft', () => {
         });
     });
 
-    describe('setdeltaPotPayoutFraction', async () => {
-        it('should restrict calling to contract owner', async () => {
-            const caller = accounts[5];
-
-            await expect(blockRewardHbbft.connect(caller).setdeltaPotPayoutFraction(1))
-                .to.be.revertedWithCustomError(blockRewardHbbft, "OwnableUnauthorizedAccount")
-                .withArgs(caller.address);
-        });
-
-        it('should not allow zero payout fraction', async () => {
-            await expect(blockRewardHbbft.setdeltaPotPayoutFraction(0))
-                .to.be.revertedWithCustomError(blockRewardHbbft, "ZeroPayoutFraction");
-        });
-
-        it('should set delta pot payout fraction and emit event', async () => {
-            const previousValue = await blockRewardHbbft.deltaPotPayoutFraction();
-            const newValue = 10;
-
-            await expect(blockRewardHbbft.setdeltaPotPayoutFraction(newValue))
-                .to.emit(blockRewardHbbft, "SetDeltaPotPayoutFraction")
-                .withArgs(newValue);
-            expect(await blockRewardHbbft.deltaPotPayoutFraction()).to.be.equal(newValue);
-
-            expect(await blockRewardHbbft.setdeltaPotPayoutFraction(previousValue));
-            expect(await blockRewardHbbft.deltaPotPayoutFraction()).to.be.equal(previousValue);
-        });
-    });
-
-    describe('setReinsertPotPayoutFraction', async () => {
-        it('should restrict calling to contract owner', async () => {
-            const caller = accounts[5];
-
-            await expect(blockRewardHbbft.connect(caller).setReinsertPotPayoutFraction(1))
-                .to.be.revertedWithCustomError(blockRewardHbbft, "OwnableUnauthorizedAccount")
-                .withArgs(caller.address);
-        });
-
-        it('should not allow zero payout fraction', async () => {
-            await expect(blockRewardHbbft.setReinsertPotPayoutFraction(0))
-                .to.be.revertedWithCustomError(blockRewardHbbft, "ZeroPayoutFraction");
-        });
-
-        it('should set reinsert pot payout fraction and emit event', async () => {
-            const previousValue = await blockRewardHbbft.reinsertPotPayoutFraction();
-            const newValue = 10;
-
-            await expect(blockRewardHbbft.setReinsertPotPayoutFraction(newValue))
-                .to.emit(blockRewardHbbft, "SetReinsertPotPayoutFraction")
-                .withArgs(newValue);
-            expect(await blockRewardHbbft.reinsertPotPayoutFraction()).to.be.equal(newValue);
-
-            expect(await blockRewardHbbft.setReinsertPotPayoutFraction(previousValue));
-            expect(await blockRewardHbbft.reinsertPotPayoutFraction()).to.be.equal(previousValue);
-        });
-    });
-
     describe('setGovernancePotShareNominator', async () => {
         let GovernancePotShareNominatorAllowedParams = new Array(11).fill(null).map((_, i) => i + 10);
 
@@ -558,34 +502,6 @@ describe('BlockRewardHbbft', () => {
                 await blockRewardHbbft.setGovernancePotShareNominator(val);
                 expect(await blockRewardHbbft.governancePotShareNominator()).to.equal(val);
             }
-        });
-    });
-
-    describe('setConnectivityTracker', async () => {
-        it('should restrict calling to contract owner', async () => {
-            const caller = accounts[5];
-
-            await expect(blockRewardHbbft.connect(caller).setConnectivityTracker(ethers.ZeroAddress))
-                .to.be.revertedWithCustomError(blockRewardHbbft, "OwnableUnauthorizedAccount")
-                .withArgs(caller.address);
-        });
-
-        it('should revert set zero address', async () => {
-            await expect(blockRewardHbbft.setConnectivityTracker(ethers.ZeroAddress))
-                .to.be.revertedWithCustomError(blockRewardHbbft, "ZeroAddress");
-        });
-
-        it('should set connectivity tracker address and emit event', async () => {
-            const previousValue = await blockRewardHbbft.connectivityTracker();
-            const newValue = accounts[7];
-
-            await expect(blockRewardHbbft.setConnectivityTracker(newValue))
-                .to.emit(blockRewardHbbft, "SetConnectivityTracker")
-                .withArgs(newValue);
-            expect(await blockRewardHbbft.connectivityTracker()).to.be.equal(newValue);
-
-            expect(await blockRewardHbbft.setConnectivityTracker(previousValue));
-            expect(await blockRewardHbbft.connectivityTracker()).to.be.equal(previousValue);
         });
     });
 

--- a/test/ConnectivityTrackerHbbft.ts
+++ b/test/ConnectivityTrackerHbbft.ts
@@ -335,30 +335,6 @@ describe('ConnectivityTrackerHbbft', () => {
         });
     });
 
-    describe('setEarlyEpochEndToleranceLevel', async () => {
-        it("should revert calling function by unauthorized account", async function () {
-            const { connectivityTracker } = await helpers.loadFixture(deployContracts);
-            const caller = accounts[4];
-
-            await expect(
-                connectivityTracker.connect(caller).setEarlyEpochEndToleranceLevel(5)
-            ).to.be.revertedWithCustomError(connectivityTracker, "OwnableUnauthorizedAccount")
-                .withArgs(caller.address);
-        });
-
-        it("should set early epoch end tolerance level and emit event", async function () {
-            const { connectivityTracker } = await helpers.loadFixture(deployContracts);
-            const newValue = 5;
-
-            await expect(
-                connectivityTracker.connect(owner).setEarlyEpochEndToleranceLevel(newValue)
-            ).to.emit(connectivityTracker, "SetEarlyEpochEndToleranceLevel")
-                .withArgs(newValue);
-
-            expect(await connectivityTracker.earlyEpochEndToleranceLevel()).to.equal(newValue);
-        });
-    });
-
     describe('reportMissingConnectivity', async () => {
         it("should restrict calling function only to validators", async () => {
             const { connectivityTracker } = await helpers.loadFixture(deployContracts);

--- a/test/StakingHbbft.ts
+++ b/test/StakingHbbft.ts
@@ -2637,7 +2637,7 @@ describe('StakingHbbft', () => {
         });
     });
 
-    describe('setStakingTransitionTimeframeLength()', async () => {
+    describe.skip('setStakingTransitionTimeframeLength()', async () => {
         it('should allow calling only to contract owner', async () => {
             const { stakingHbbft } = await helpers.loadFixture(deployContractsFixture);
 
@@ -2670,7 +2670,7 @@ describe('StakingHbbft', () => {
 
     });
 
-    describe('setStakingFixedEpochDuration()', async () => {
+    describe.skip('setStakingFixedEpochDuration()', async () => {
         it('should allow calling only to contract owner', async () => {
             const { stakingHbbft } = await helpers.loadFixture(deployContractsFixture);
 

--- a/test/ValidatorSetHbbft.ts
+++ b/test/ValidatorSetHbbft.ts
@@ -522,35 +522,6 @@ describe('ValidatorSetHbbft', () => {
         });
     });
 
-    describe('setValidatorInactivityThreshold', async () => {
-        it('fail to set threshold less than a week', async () => {
-            const { validatorSetHbbft } = await helpers.loadFixture(deployContractsFixture);
-
-            const value = 60 * 60 * 24 * 7 - 1;
-
-            await expect(validatorSetHbbft.setValidatorInactivityThreshold(value))
-                .to.be.revertedWithCustomError(validatorSetHbbft, "InvalidInactivityThreshold");
-        });
-
-        it('correct value is set', async () => {
-            const { validatorSetHbbft } = await helpers.loadFixture(deployContractsFixture);
-
-            let value30Days = 2592000;
-            await validatorSetHbbft.setValidatorInactivityThreshold(value30Days);
-            expect(await validatorSetHbbft.validatorInactivityThreshold()).to.be.equal(value30Days);
-        });
-
-        it('only owner should be able to change value', async () => {
-            const { validatorSetHbbft } = await helpers.loadFixture(deployContractsFixture);
-            let nobody = (await ethers.getSigners())[42];
-            let value30Days = 2592000;
-
-            await expect(validatorSetHbbft.connect(nobody).setValidatorInactivityThreshold(value30Days))
-                .to.be.revertedWithCustomError(validatorSetHbbft, "OwnableUnauthorizedAccount")
-                .withArgs(nobody.address);
-        });
-    });
-
     describe('setValidatorInternetAddress', async () => {
         let validatorSetPermission: Permission<ValidatorSetHbbftMock>
 
@@ -683,68 +654,6 @@ describe('ValidatorSetHbbft', () => {
                 }
                 ipLast++;
             }
-        });
-    });
-
-    describe('setBonusScoreSystemAddress', async () => {
-        it('should restrict calling to contract owner', async () => {
-            const { validatorSetHbbft } = await helpers.loadFixture(deployContractsFixture);
-
-            const caller = accounts[10];
-
-            await expect(validatorSetHbbft.connect(caller).setBonusScoreSystemAddress(ethers.ZeroAddress))
-                .to.be.revertedWithCustomError(validatorSetHbbft, "OwnableUnauthorizedAccount")
-                .withArgs(caller.address);
-        });
-
-        it('should revert set zero address', async () => {
-            const { validatorSetHbbft } = await helpers.loadFixture(deployContractsFixture);
-
-            await expect(validatorSetHbbft.setBonusScoreSystemAddress(ethers.ZeroAddress))
-                .to.be.revertedWithCustomError(validatorSetHbbft, "ZeroAddress");
-        });
-
-        it('should set new address and emit event', async () => {
-            const { validatorSetHbbft } = await helpers.loadFixture(deployContractsFixture);
-
-            const newAddress = accounts[11].address;
-
-            expect(await validatorSetHbbft.setBonusScoreSystemAddress(newAddress))
-                .to.emit(validatorSetHbbft, "SetBonusScoreContract")
-                .withArgs(newAddress);
-
-            expect(await validatorSetHbbft.bonusScoreSystem()).to.equal(newAddress);
-        });
-    });
-
-    describe('setConnectivityTracker', async () => {
-        it('should restrict calling to contract owner', async () => {
-            const { validatorSetHbbft } = await helpers.loadFixture(deployContractsFixture);
-
-            const caller = accounts[10];
-
-            await expect(validatorSetHbbft.connect(caller).setConnectivityTracker(ethers.ZeroAddress))
-                .to.be.revertedWithCustomError(validatorSetHbbft, "OwnableUnauthorizedAccount")
-                .withArgs(caller.address);
-        });
-
-        it('should revert set zero address', async () => {
-            const { validatorSetHbbft } = await helpers.loadFixture(deployContractsFixture);
-
-            await expect(validatorSetHbbft.setConnectivityTracker(ethers.ZeroAddress))
-                .to.be.revertedWithCustomError(validatorSetHbbft, "ZeroAddress");
-        });
-
-        it('should set new address and emit event', async () => {
-            const { validatorSetHbbft } = await helpers.loadFixture(deployContractsFixture);
-
-            const newAddress = accounts[11].address;
-
-            expect(await validatorSetHbbft.setConnectivityTracker(newAddress))
-                .to.emit(validatorSetHbbft, "SetConnectivityTrackerContract")
-                .withArgs(newAddress);
-
-            expect(await validatorSetHbbft.connectivityTracker()).to.equal(newAddress);
         });
     });
 
@@ -1131,29 +1040,6 @@ describe('ValidatorSetHbbft', () => {
             await expect(validatorSetHbbft.connect(blockRewardSigner).finalizeChange()).to.be.fulfilled;
 
             await helpers.stopImpersonatingAccount(blockRewardSigner.address);
-        });
-    });
-
-    describe('setMaxValidators', async () => {
-        it("should restrict calling to contract owner", async () => {
-            const { validatorSetHbbft } = await helpers.loadFixture(deployContractsFixture);
-
-            const caller = accounts[5];
-
-            await expect(validatorSetHbbft.connect(caller).setMaxValidators(0n))
-                .to.be.revertedWithCustomError(validatorSetHbbft, "OwnableUnauthorizedAccount")
-                .withArgs(caller.address);
-        });
-
-        it("should set max validators", async () => {
-            const { validatorSetHbbft } = await helpers.loadFixture(deployContractsFixture);
-            const newValue = 50n;
-
-            await expect(validatorSetHbbft.connect(owner).setMaxValidators(newValue))
-                .to.emit(validatorSetHbbft, "SetMaxValidators")
-                .withArgs(newValue);
-
-            expect(await validatorSetHbbft.maxValidators()).to.equal(newValue);
         });
     });
 


### PR DESCRIPTION
**This PR includes following changes:** 

- removed all of the contracts cross reference setters (some of them was moved to mock contracts for unit testing);
- removed all setters for chain parameters that should only be changeable using contract upgrade;
- corresponding update of unit tests.

**To discuss:** 

- setStakingTransitionTimeframeLength function removal, commit 0ee80a486a0d2b3fff5968ea14a57a7f87bc1c32
- setStakingFixedEpochDuration function removal, commit 0ee80a486a0d2b3fff5968ea14a57a7f87bc1c32
- setEarlyEpochEndToleranceLevel function removal, commit a2078537e13e1c6c466bce593c9d326551089358

**Affected contracts:**  

- BlockRewardHbbft
- ValidatorSetHbbft
- StakingHbbft
- TxPermissionHbbft
- BonusScoreSystem