### PR TITLE
[M-5] Remove stake withdraw time restrictions

### DIFF
--- a/contracts/BlockRewardHbbft.sol
+++ b/contracts/BlockRewardHbbft.sol
@@ -409,7 +409,7 @@ contract BlockRewardHbbft is
             // notify staking contract this epoch will end earlier due to
             // upscaling or too many validators were marked as faulty
             if (!isPhaseTransition) {
-                stakingContract.notifiyEarlyEpochEnd(block.timestamp);
+                stakingContract.notifyEarlyEpochEnd(block.timestamp);
             }
 
             // in any case we reset early epoch end flag because

--- a/contracts/StakingHbbft.sol
+++ b/contracts/StakingHbbft.sol
@@ -73,8 +73,7 @@ contract StakingHbbft is Initializable, OwnableUpgradeable, ReentrancyGuardUpgra
     /// The first parameter is the pool staking address, the second one is the staker address.
     mapping(address => mapping(address => uint256)) public stakeAmount;
 
-    /// @dev The duration period (in blocks) at the end of staking epoch during which
-    /// participants are not allowed to stake/withdraw/order/claim their staking coins.
+    /// @dev deprecated
     uint256 public stakingWithdrawDisallowPeriod;
 
     /// @dev The serial number of the current staking epoch.
@@ -287,16 +286,12 @@ contract StakingHbbft is Initializable, OwnableUpgradeable, ReentrancyGuardUpgra
     error InvalidMoveStakePoolsAddress();
     error InvalidOrderWithdrawAmount(address pool, address delegator, int256 amount);
     error InvalidPublicKeysCount();
-    error InvalidStakingTransitionTimeframe();
-    error InvalidStakingFixedEpochDuration();
     error InvalidTransitionTimeFrame();
     error InvalidWithdrawAmount(address pool, address delegator, uint256 amount);
     error InvalidNodeOperatorConfiguration(address _operator, uint256 _share);
     error InvalidNodeOperatorShare(uint256 _share);
     error InvalidPublicKey();
-    error WithdrawNotAllowed();
     error ZeroWidthrawAmount();
-    error ZeroWidthrawDisallowPeriod();
     error MiningAddressPublicKeyMismatch();
 
     // ============================================== Modifiers =======================================================
@@ -355,7 +350,7 @@ contract StakingHbbft is Initializable, OwnableUpgradeable, ReentrancyGuardUpgra
     ///  _stakingFixedEpochDuration The fixed duration of each epoch before keyGen starts.
     ///  _stakingTransitionTimeframeLength Length of the timeframe in seconds for the transition
     /// to the new validator set.
-    ///  _stakingWithdrawDisallowPeriod The duration period at the end of a staking epoch
+    ///  _stakingWithdrawDisallowPeriod Deprecated. Left to not break compatibility.
     /// during which participants cannot stake/withdraw/order/claim their staking coins
     function initialize(
         address _contractOwner,
@@ -416,7 +411,6 @@ contract StakingHbbft is Initializable, OwnableUpgradeable, ReentrancyGuardUpgra
         maxStakeAmount = stakingParams._maxStake;
 
         stakingFixedEpochDuration = stakingParams._stakingFixedEpochDuration;
-        stakingWithdrawDisallowPeriod = stakingParams._stakingWithdrawDisallowPeriod;
 
         // note: this might be still 0 when created in the genesis block.
         stakingEpochStartTime = block.timestamp;
@@ -1187,15 +1181,8 @@ contract StakingHbbft is Initializable, OwnableUpgradeable, ReentrancyGuardUpgra
     }
 
     function _validateStakingParams(StakingParams calldata params) private pure {
-        if (
-            params._stakingFixedEpochDuration == 0 ||
-            params._stakingFixedEpochDuration <= params._stakingWithdrawDisallowPeriod
-        ) {
+        if (params._stakingFixedEpochDuration == 0) {
             revert InvalidFixedEpochDuration();
-        }
-
-        if (params._stakingWithdrawDisallowPeriod == 0) {
-            revert ZeroWidthrawDisallowPeriod();
         }
 
         if (

--- a/contracts/StakingHbbft.sol
+++ b/contracts/StakingHbbft.sol
@@ -498,7 +498,7 @@ contract StakingHbbft is Initializable, OwnableUpgradeable, ReentrancyGuardUpgra
         }
     }
 
-    function notifiyEarlyEpochEnd(uint256 timestamp) external onlyBlockRewardContract {
+    function notifyEarlyEpochEnd(uint256 timestamp) external onlyBlockRewardContract {
         earlyEpochEndTriggerTime = timestamp;
     }
 
@@ -868,11 +868,11 @@ contract StakingHbbft is Initializable, OwnableUpgradeable, ReentrancyGuardUpgra
         uint256 governanceShare = totalAbandonedAmount / 2;
         uint256 reinsertShare = totalAbandonedAmount - governanceShare;
 
-        address blockRewarAddress = validatorSetContract.blockRewardContract();
+        address blockRewardAddress = validatorSetContract.blockRewardContract();
         IBlockRewardHbbft blockRewardHbbft = IBlockRewardHbbft(validatorSetContract.blockRewardContract());
         address governanceAddress = blockRewardHbbft.getGovernanceAddress();
 
-        TransferUtils.transferNative(blockRewarAddress, reinsertShare);
+        TransferUtils.transferNative(blockRewardAddress, reinsertShare);
         TransferUtils.transferNative(governanceAddress, governanceShare);
 
         emit RecoverAbandonedStakes(msg.sender, reinsertShare, governanceShare);

--- a/contracts/interfaces/IStakingHbbft.sol
+++ b/contracts/interfaces/IStakingHbbft.sol
@@ -34,7 +34,7 @@ interface IStakingHbbft {
 
     function notifyNetworkOfftimeDetected(uint256) external;
 
-    function notifiyEarlyEpochEnd(uint256 timestamp) external;
+    function notifyEarlyEpochEnd(uint256 timestamp) external;
 
     function updatePoolLikelihood(address mining, uint256 validatorScore) external;
 

--- a/test/BonusScoreSystem.ts
+++ b/test/BonusScoreSystem.ts
@@ -463,44 +463,6 @@ describe("BonusScoreSystem", function () {
         });
     });
 
-    describe.skip('updateScoringFactor', async () => {
-        const TestCases = [
-            { factor: ScoringFactor.StandByBonus, value: 20 },
-            { factor: ScoringFactor.NoStandByPenalty, value: 50 },
-            { factor: ScoringFactor.NoKeyWritePenalty, value: 200 },
-            { factor: ScoringFactor.BadPerformancePenalty, value: 199 },
-        ];
-
-        it('should restrict calling to contract owner', async function () {
-            const { bonusScoreSystem } = await helpers.loadFixture(deployContracts);
-            const caller = users[2];
-
-            await expect(bonusScoreSystem.connect(caller).updateScoringFactor(ScoringFactor.StandByBonus, 1))
-                .to.be.revertedWithCustomError(bonusScoreSystem, "OwnableUnauthorizedAccount")
-                .withArgs(caller.address);
-        });
-
-        it('should not allow zero factor value', async function () {
-            const { bonusScoreSystem } = await helpers.loadFixture(deployContracts);
-
-            await expect(bonusScoreSystem.updateScoringFactor(ScoringFactor.StandByBonus, 0))
-                .to.be.revertedWithCustomError(bonusScoreSystem, "ZeroFactorValue");
-        });
-
-        TestCases.forEach((args) => {
-            it(`should set scoring factor ${ScoringFactor[args.factor]} and emit event`, async function () {
-                const { bonusScoreSystem } = await helpers.loadFixture(deployContracts);
-
-                await expect(
-                    bonusScoreSystem.updateScoringFactor(args.factor, args.value)
-                ).to.emit(bonusScoreSystem, "UpdateScoringFactor")
-                    .withArgs(args.factor, args.value);
-
-                expect(await bonusScoreSystem.getScoringFactorValue(args.factor)).to.equal(args.value);
-            });
-        });
-    });
-
     describe('getScoringFactorValue', async () => {
         it('should revert for unknown scoring factor', async function () {
             const { bonusScoreSystem } = await helpers.loadFixture(deployContracts);

--- a/test/StakingHbbft.ts
+++ b/test/StakingHbbft.ts
@@ -550,30 +550,6 @@ describe('StakingHbbft', () => {
             expect(await stakingHbbft.isPoolActive(candidate.stakingAddress())).to.be.true;
             expect(await stakingHbbft.getPoolsInactive()).to.be.empty;
         });
-
-        it.skip('should fail if staking time is inside disallowed range', async function () {
-            const { stakingHbbft } = await helpers.loadFixture(deployContractsFixture);
-
-            await expect(stakingHbbft.connect(candidate.staking).addPool(
-                candidate.miningAddress(),
-                ethers.ZeroAddress,
-                0n,
-                candidate.publicKey(),
-                candidate.ipAddress,
-                { value: minStake },
-            )).to.be.revertedWith("Stake: disallowed period");
-
-            await helpers.time.increase(2);
-
-            await stakingHbbft.connect(candidate.staking).addPool(
-                candidate.miningAddress(),
-                ethers.ZeroAddress,
-                0n,
-                candidate.publicKey(),
-                candidate.ipAddress,
-                { value: minStake },
-            );
-        });
     });
 
     describe('setNodeOperator', async function () {
@@ -1542,15 +1518,6 @@ describe('StakingHbbft', () => {
             expect(await stakingHbbft.getStakeSnapshotLastEpoch(pool.address, delegator.address))
                 .to.be.equal(stakingEpoch);
         });
-
-        it.skip('should only success in the allowed staking window', async function () {
-            const { stakingHbbft, candidateMinStake } = await helpers.loadFixture(deployContractsFixture);
-
-            const pool = initialValidators[1].staking;
-
-            await expect(stakingHbbft.connect(pool).stake(pool.address, { value: candidateMinStake }))
-                .to.be.revertedWith("Stake: disallowed period");
-        });
     });
 
     describe('removePool', async function () {
@@ -1930,26 +1897,6 @@ describe('StakingHbbft', () => {
             likelihoodInfo = await stakingHbbft.getPoolsLikelihood();
             expect(likelihoodInfo.likelihoods[0]).to.be.equal(stakeAmount / 2n);
             expect(likelihoodInfo.sum).to.be.equal(stakeAmount / 2n);
-        });
-
-        it.skip("shouldn't allow withdrawing during the stakingWithdrawDisallowPeriod", async function () {
-            const { stakingHbbft } = await helpers.loadFixture(deployContractsFixture);
-
-            const pool = initialValidators[1].staking;
-
-            await stakingHbbft.connect(pool).stake(pool.address, { value: stakeAmount });
-
-            //await stakingHbbft.setCurrentBlockNumber(117000);
-            //await validatorSetHbbft.setCurrentBlockNumber(117000);
-            await expect(stakingHbbft.connect(pool).withdraw(
-                pool.address,
-                stakeAmount,
-            )).to.be.revertedWith("Stake: disallowed period");
-
-            //await stakingHbbft.setCurrentBlockNumber(116000);
-            //await validatorSetHbbft.setCurrentBlockNumber(116000);
-
-            await stakingHbbft.connect(pool).withdraw(pool.address, stakeAmount);
         });
     });
 

--- a/test/StakingHbbft.ts
+++ b/test/StakingHbbft.ts
@@ -2785,11 +2785,11 @@ describe('StakingHbbft', () => {
                 .to.be.revertedWithCustomError(stakingHbbft, "Unauthorized");
         });
 
-        it('should restrict calling notifiyEarlyEpochEnd to block reward contract', async function () {
+        it('should restrict calling notifyEarlyEpochEnd to block reward contract', async function () {
             const { stakingHbbft } = await helpers.loadFixture(deployContractsFixture);
             const caller = accounts[10];
 
-            await expect(stakingHbbft.connect(caller).notifiyEarlyEpochEnd(0n))
+            await expect(stakingHbbft.connect(caller).notifyEarlyEpochEnd(0n))
                 .to.be.revertedWithCustomError(stakingHbbft, "Unauthorized");
         });
 

--- a/test/StakingHbbft.ts
+++ b/test/StakingHbbft.ts
@@ -2779,65 +2779,6 @@ describe('StakingHbbft', () => {
         });
     });
 
-    describe.skip('setStakingTransitionTimeframeLength', async function () {
-        it('should allow calling only to contract owner', async function () {
-            const { stakingHbbft } = await helpers.loadFixture(deployContractsFixture);
-
-            const caller = accounts[5];
-            await expect(stakingHbbft.connect(caller).setStakingTransitionTimeframeLength(300n))
-                .to.be.revertedWithCustomError(stakingHbbft, "OwnableUnauthorizedAccount")
-                .withArgs(caller.address);
-        });
-
-        it('should set staking transition time frame length', async function () {
-            const { stakingHbbft } = await helpers.loadFixture(deployContractsFixture);
-
-            await stakingHbbft.setStakingTransitionTimeframeLength(300n);
-            expect(await stakingHbbft.stakingTransitionTimeframeLength()).to.be.equal(300n);
-        });
-
-        it('should not set staking transition time frame length to low value', async function () {
-            const { stakingHbbft } = await helpers.loadFixture(deployContractsFixture);
-
-            await expect(stakingHbbft.setStakingTransitionTimeframeLength(9n))
-                .to.be.revertedWithCustomError(stakingHbbft, "InvalidStakingTransitionTimeframe");
-        });
-
-        it('should not set staking transition time frame length to high value', async function () {
-            const { stakingHbbft } = await helpers.loadFixture(deployContractsFixture);
-
-            await expect(stakingHbbft.setStakingTransitionTimeframeLength(100000n))
-                .to.be.revertedWithCustomError(stakingHbbft, "InvalidStakingTransitionTimeframe");
-        });
-
-    });
-
-    describe.skip('setStakingFixedEpochDuration', async function () {
-        it('should allow calling only to contract owner', async function () {
-            const { stakingHbbft } = await helpers.loadFixture(deployContractsFixture);
-
-            const caller = accounts[5];
-            await expect(stakingHbbft.connect(caller).setStakingFixedEpochDuration(600000n))
-                .to.be.revertedWithCustomError(stakingHbbft, "OwnableUnauthorizedAccount")
-                .withArgs(caller.address);
-        });
-
-        it('should set staking fixed epoch transition', async function () {
-            const { stakingHbbft } = await helpers.loadFixture(deployContractsFixture);
-
-            await stakingHbbft.setStakingFixedEpochDuration(600000n);
-            expect(await stakingHbbft.stakingFixedEpochDuration()).to.be.equal(600000n);
-        });
-
-        it('should not set staking transition time frame length to low value', async function () {
-            const { stakingHbbft } = await helpers.loadFixture(deployContractsFixture);
-
-            let tranitionTimeFrame = await stakingHbbft.stakingTransitionTimeframeLength();
-            await expect(stakingHbbft.setStakingFixedEpochDuration(tranitionTimeFrame))
-                .to.be.revertedWithCustomError(stakingHbbft, "InvalidStakingFixedEpochDuration");
-        });
-    });
-
     async function callReward(blockRewardContract: BlockRewardHbbftMock, isEpochEndBlock: boolean) {
         const systemSigner = await impersonateAcc(SystemAccountAddress);
 

--- a/test/StakingHbbft.ts
+++ b/test/StakingHbbft.ts
@@ -774,7 +774,7 @@ describe('StakingHbbft', () => {
             await stakingHbbft.waitForDeployment();
 
             expect(await stakingHbbft.stakingFixedEpochDuration()).to.be.equal(stakingFixedEpochDuration);
-            expect(await stakingHbbft.stakingWithdrawDisallowPeriod()).to.be.equal(stakingWithdrawDisallowPeriod);
+            expect(await stakingHbbft.stakingWithdrawDisallowPeriod()).to.be.equal(0);
             expect(await stakingHbbft.validatorSetContract()).to.be.equal(validatorSetContract)
 
             for (const stakingAddress of initStakingAddresses) {
@@ -906,44 +906,6 @@ describe('StakingHbbft', () => {
             const params = {
                 ...stakingParams,
                 _stakingFixedEpochDuration: 0
-            }
-
-            const StakingHbbftFactory = await ethers.getContractFactory("StakingHbbftMock");
-            await expect(upgrades.deployProxy(
-                StakingHbbftFactory,
-                [
-                    owner.address,
-                    params,
-                    initPublicKeys, // _publicKeys
-                    initIpAddresses // _internetAddresses
-                ],
-                { initializer: 'initialize' }
-            )).to.be.revertedWithCustomError(StakingHbbftFactory, "InvalidFixedEpochDuration");
-        });
-
-        it('should fail if stakingWithdrawDisallowPeriod is 0', async function () {
-            const params = {
-                ...stakingParams,
-                _stakingWithdrawDisallowPeriod: 0n
-            }
-
-            const StakingHbbftFactory = await ethers.getContractFactory("StakingHbbftMock");
-            await expect(upgrades.deployProxy(
-                StakingHbbftFactory,
-                [
-                    owner.address,
-                    params,
-                    initPublicKeys, // _publicKeys
-                    initIpAddresses // _internetAddresses
-                ],
-                { initializer: 'initialize' }
-            )).to.be.revertedWithCustomError(StakingHbbftFactory, "ZeroWidthrawDisallowPeriod");
-        });
-
-        it('should fail if stakingWithdrawDisallowPeriod >= stakingEpochDuration', async function () {
-            const params = {
-                ...stakingParams,
-                _stakingWithdrawDisallowPeriod: 120954n
             }
 
             const StakingHbbftFactory = await ethers.getContractFactory("StakingHbbftMock");


### PR DESCRIPTION
Changes:
- stake/withdraw disallow period restrictions removed from StakingHbbft contract;
- corresponding unit tests was removed;
- other rudimentary tests was removed.

Closes #288 